### PR TITLE
Add Seurat label transfer

### DIFF
--- a/scripts/project_only_seurat.r
+++ b/scripts/project_only_seurat.r
@@ -4,18 +4,28 @@ library(Matrix)
 
 # For multiple queries just projects every query to the reference.
 # .X should have unnormalized counts.
-project_only_seurat <- function(adata_file, batch_col, query_names, dim=50)
+project_only_seurat <- function(adata_file, batch_col, query_names, label_col=NULL, dim=50)
 {
 
   ad <- read_h5ad(adata_file)
 
-  if (is(ad$X, "dgRMatrix")) {
-      ad$X <- as(ad$X, "CsparseMatrix")
-  }
+  # Sort ad by batch with queries last
+  batch_names <- as.character(unique(ad$obs[[batch_col]]))
+  is_query <- batch_names %in% query_names
+  batch_names <- c(sort(batch_names[!is_query]), sort(batch_names[is_query]))
+  batch_order <- order(factor(ad$obs[[batch_col]], levels = batch_names))
+  ad <- ad[batch_order, ]
 
-  se <- CreateSeuratObject(counts=t(ad$X))
+  se <- CreateSeuratObject(counts=t(as(ad$X, "CsparseMatrix")))
   VariableFeatures(se) <- rownames(se)
   se[[batch_col]] <- ad$obs[[batch_col]]
+
+  do_transfer <- !is.null(label_col)
+
+  if (do_transfer) {
+      se[[label_col]] <- ad$obs[[label_col]]
+      n_ref <- sum(!(se[[]][[batch_col]] %in% query_names))
+  }
 
   datas <- SplitObject(se, split.by = batch_col)
   rm(se)
@@ -48,6 +58,11 @@ project_only_seurat <- function(adata_file, batch_col, query_names, dim=50)
 
   latent <- Embeddings(ref, reduction = "spca")
 
+  if (do_transfer) {
+      pred_labels <- rep(NA, n_ref)
+      pred_scores <- rep(NA, n_ref)
+  }
+
   for (i in 1:length(queries))
   {
     query <- queries[i]
@@ -57,6 +72,14 @@ project_only_seurat <- function(adata_file, batch_col, query_names, dim=50)
     anchors_query <- FindTransferAnchors(reference = ref, query = query, reference.reduction = "spca",
                                          reference.neighbors = "spca.nn", dims = 1:dim)
 
+    if (do_transfer) {
+        query <- TransferData(anchorset = anchors_query, reference = ref, query = query, refdata = list(label = label_col)
+        )
+
+        pred_labels <- c(pred_labels, query$predicted.label)
+        pred_scores <- c(pred_scores, query$predicted.label.score)
+    }
+
     query <- IntegrateEmbeddings(anchorset = anchors_query, reference = ref, query = query, reductions = "pcaproject",
                                  dims = 1:dim, new.reduction.name = "qrmapping", reuse.weights.matrix = FALSE)
     rm(anchors_query)
@@ -65,6 +88,11 @@ project_only_seurat <- function(adata_file, batch_col, query_names, dim=50)
   }
 
   ad$obsm[["X_seurat"]] <- latent[ad$obs_names,]
+
+  if (do_transfer) {
+      ad$obs$pred_label <- pred_labels
+      ad$obs$pred_score <- pred_scores
+  }
 
   ad$write_h5ad(adata_file)
 


### PR DESCRIPTION
Add label transfer to the `project_only_seurat.r` script. If the `label_col` argument is set these labels will be transferred to the query.

Also a couple of other little fixes for things that were breaking on my test dataset:
- Make sure that the matrix used to create the **Seurat** object is a `dgCMatrix` not a `dgRMatrix`
- Added some code to make sure cells are sorted by batch with query batches last (the existing code seemed to assume that but it's probably possible to rewrite things so this step isn't necessary)